### PR TITLE
Update URL to http2curl

### DIFF
--- a/contentful.go
+++ b/contentful.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/moul/http2curl"
+	"moul.io/http2curl"
 )
 
 // Contentful model


### PR DESCRIPTION
Other references to github.com/moul/http2curl are in Gopkg.taml and Gopkg.lock - do I need to update these as well? The code is still hosted on github.